### PR TITLE
Bump C++ version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,8 @@ setup(
                 "hgru2_pytorch/hgru_real_cuda/hgru_real_cuda.cpp",
             ],
             extra_compile_args={
-                "cxx": ["-O2", "-std=c++14", "-D_GLIBCXX_USE_CXX11_ABI=0"],
-                "nvcc": ["-O2", "-std=c++14", "-D_GLIBCXX_USE_CXX11_ABI=0"]
+                "cxx": ["-O2", "-std=c++17", "-D_GLIBCXX_USE_CXX11_ABI=0"],
+                "nvcc": ["-O2", "-std=c++17", "-D_GLIBCXX_USE_CXX11_ABI=0"]
                 + arch_flags,
             },
         ),


### PR DESCRIPTION
This fixes the build for newer PyTorch..  Works for GCC-12 but fails for GCC-13 (seems to be a PyTorch software bug that needs to be fixed).

On Ubuntu you can set the GCC version by installing it with:

```
sudo apt install gcc-12 g++-12 cpp-12
sudo update-alternatives --set g++ /usr/bin/g++-12
sudo update-alternatives --set gcc /usr/bin/gcc-12
sudo update-alternatives --set cpp-bin /usr/bin/cpp-12
```